### PR TITLE
Fix for older Emacs

### DIFF
--- a/verify-url.el
+++ b/verify-url.el
@@ -87,7 +87,7 @@
               (push url invalid-urls))))))
     (switch-to-buffer (get-buffer-create verify-url-buffer))
     (erase-buffer)
-    (insert (format "invalid urls:\n%s" (string-join  invalid-urls "\n")))))
+    (insert (format "invalid urls:\n%s" (mapconcat #'identity invalid-urls "\n")))))
 
 (provide 'verify-url)
 


### PR DESCRIPTION
string-join was introduced at Emacs 24.4. And subr-x.el must be
loaded for using it.
