### PR TITLE
Specify parent group for customize

### DIFF
--- a/verify-url.el
+++ b/verify-url.el
@@ -48,7 +48,8 @@
 
 (defgroup verify-url nil
   "verify url group"
-  :prefix "verify-url")
+  :prefix "verify-url"
+  :group 'url)
 
 (defcustom verify-url-regex
   "\\(file\\|ftp\\|http\\|https\\)://[^][:blank:]\r\n<>{}()*#$^['\\|]+"


### PR DESCRIPTION
This also fix following byte-compile warning.

```
verify-url.el:49:1:Warning: defgroup for `verify-url' fails to specify
    containing group
```
