### PR TITLE
Remove url from dependency

### DIFF
--- a/verify-url.el
+++ b/verify-url.el
@@ -6,7 +6,7 @@
 ;; Created: 2015-12-21
 ;; Version: 0.1
 ;; Keywords: convenience, usability, url
-;; Package-Requires: ((cl-lib "0.5") (url) )
+;; Package-Requires: ((cl-lib "0.5"))
 ;; URL: https://github.com/lujun9972/verify-url
 
 ;; This file is NOT part of GNU Emacs.


### PR DESCRIPTION
Because url is a standard package.
This causes warning of melpa test(https://travis-ci.org/milkypostman/melpa/builds/104092117#L2045-L2057)
