### PR TITLE
Don't hardcode red color

### DIFF
--- a/verify-url.el
+++ b/verify-url.el
@@ -64,7 +64,7 @@
   "If non-nil, automatically jump to the first invalid url")
 
 (defface verify-url/invalid-url-face '((t :underline t
-                                          :foreground "red"))
+                                          :inherit 'font-lock-warning-face))
          "Face for the invalid url."
          :group 'verify-url)
 


### PR DESCRIPTION
Use the default warning color instead, as the base. This plays nicer
with the colors of the current theme. Otherwise it can look really
jarring.
